### PR TITLE
Delete plugin directory when uninstalling

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "fuzzyfind": "^2.0.0",
-    "node-fetch": "^1.6.3"
+    "node-fetch": "^1.6.3",
+    "rimraf": "^2.6.1"
   }
 }

--- a/src/configPath.js
+++ b/src/configPath.js
@@ -1,5 +1,0 @@
-const os = require('os')
-const path = require('path')
-const home = process.env.ZAZU_HOME || os.homedir()
-
-module.exports = path.join(home, '.zazurc.json')

--- a/src/install.js
+++ b/src/install.js
@@ -1,6 +1,6 @@
 const fuzzyfind = require('fuzzyfind')
 const packages = require('./packages')
-const configPath = require('./configPath')
+const { configPath } = require('./path')
 
 module.exports = ({ cwd }) => {
   const zazuConfig = require(configPath)

--- a/src/installPlugin.js
+++ b/src/installPlugin.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const packages = require('./packages')
-const configPath = require('./configPath')
+const { configPath } = require('./path')
 const zazuConfig = require(configPath)
 
 module.exports = ({ cwd }) => {

--- a/src/list.js
+++ b/src/list.js
@@ -1,6 +1,7 @@
 const fuzzyfind = require('fuzzyfind')
 const packages = require('./packages')
-const zazuConfig = require(require('./configPath'))
+const { configPath } = require('./path')
+const zazuConfig = require(configPath)
 
 module.exports = ({ cwd }) => {
   return (query, env = {}) => {

--- a/src/openConfig.js
+++ b/src/openConfig.js
@@ -1,4 +1,4 @@
-const configPath = require('./configPath')
+const { configPath } = require('./path')
 
 module.exports = (pluginContext) => {
   return (query, env = {}) => {

--- a/src/path.js
+++ b/src/path.js
@@ -1,0 +1,8 @@
+const os = require('os')
+const path = require('path')
+const home = process.env.ZAZU_HOME || os.homedir()
+
+module.exports = {
+  configPath: path.join(home, '.zazurc.json'),
+  pluginPath: path.join(home, '.zazu', 'plugins'),
+}

--- a/src/showConfig.js
+++ b/src/showConfig.js
@@ -1,4 +1,4 @@
-const configPath = require('./configPath')
+const { configPath } = require('./path')
 
 module.exports = (pluginContext) => {
   return (query, env = {}) => {

--- a/src/uninstallPlugin.js
+++ b/src/uninstallPlugin.js
@@ -1,10 +1,12 @@
 const fs = require('fs')
-const configPath = require('./configPath')
+const rimraf = require('rimraf')
+const path = require('path')
+const { configPath, pluginPath } = require('./path')
 const zazuConfig = require(configPath)
 
 module.exports = () => {
   return (value, env = {}) => {
-    return new Promise((resolve, reject) => {
+    const updateConfig = new Promise((resolve, reject) => {
       zazuConfig.plugins = zazuConfig.plugins.filter((plugin) => {
         const name = typeof plugin === 'string' ? plugin : plugin.name
         return name !== value
@@ -14,5 +16,13 @@ module.exports = () => {
         err ? reject(err) : resolve()
       })
     })
+
+    const deletePlugin = new Promise((resolve, reject) => {
+      rimraf(path.join(pluginPath, value), (err) => {
+        err ? reject(err) : resolve()
+      })
+    })
+
+    return Promise.all([updateConfig, deletePlugin])
   }
 }

--- a/test/hello.spec.js
+++ b/test/hello.spec.js
@@ -1,9 +1,0 @@
-const expect = require('chai').expect
-
-describe('calculator', () => {
-  describe('addition', () => {
-    it('works', () => {
-      expect(5 * 2).to.eq(10)
-    })
-  })
-})

--- a/test/zazu.spec.js
+++ b/test/zazu.spec.js
@@ -1,0 +1,8 @@
+const expect = require('chai').expect
+
+describe('zazu.json', () => {
+  it('is valid', () => {
+    const zazu = require('../zazu.json')
+    expect(zazu).to.be.an('object')
+  })
+})


### PR DESCRIPTION
When uninstalling a plugin, we should delete the plugin as well. This way if a user has a problem they can get a fresh copy of the plugin by uninstalling and reinstalling it.