### PR TITLE
Allow packages to be installed directly from GitHub.

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -21,6 +21,7 @@ module.exports = ({ cwd }) => {
       }).map((plugin) => {
         return {
           icon: plugin.type === 'plugin' ? 'fa-plug' : 'fa-paint-brush',
+          id: plugin.title,
           title: plugin.title,
           subtitle: plugin.description,
           value: plugin.githuburl,

--- a/src/installDirect.js
+++ b/src/installDirect.js
@@ -1,0 +1,24 @@
+const { configPath } = require('./path')
+
+module.exports = () => {
+  const zazuConfig = require(configPath)
+  const installedPlugins = zazuConfig.plugins.map((plugin) => {
+    return typeof plugin === 'string' ? plugin : plugin.name
+  })
+
+  const hasGitHubLikeName = (query) => !!query.match(/.\/./)
+  const isInstalled = (query) => !!installedPlugins.find((p) => p === query)
+
+  return (query, env = {}) => {
+    if (hasGitHubLikeName(query) && !isInstalled(query)) {
+      return Promise.resolve([
+        {
+          icon: 'fa-plug',
+          title: `Install package '${query}' from GitHub`,
+          value: query,
+        },
+      ])
+    }
+    return Promise.resolve([])
+  }
+}

--- a/src/installPlugin.js
+++ b/src/installPlugin.js
@@ -10,6 +10,12 @@ module.exports = ({ cwd }) => {
         return plugin.githuburl === value
       })
     }).then((plugin) => {
+      if (plugin) return plugin
+      return {
+        githuburl: value,
+        type: 'package',
+      }
+    }).then((plugin) => {
       return new Promise((resolve, reject) => {
         if (plugin.type === 'theme') {
           zazuConfig.theme = plugin.githuburl

--- a/zazu.json
+++ b/zazu.json
@@ -21,6 +21,15 @@
         "connections": ["InstallPlugin", "GotoRepo"]
       },
       {
+        "id": "InstallDirect",
+        "type": "PrefixScript",
+        "prefix": "install",
+        "space": true,
+        "args": "Required",
+        "script": "src/installDirect.js",
+        "connections": ["InstallPlugin", "GotoRepo"]
+      },
+      {
         "id": "UninstallSearch",
         "type": "PrefixScript",
         "prefix": "uninstall",


### PR DESCRIPTION
This makes it so Zazu doesn't need to know about the plugin for it to be
installed via the interface.

sidekick: @tinytacoteam/zazu-core 